### PR TITLE
Managed category url_key attribute for Magento EE

### DIFF
--- a/app/code/community/Mbiz/TrackingTags/Model/Config.php
+++ b/app/code/community/Mbiz/TrackingTags/Model/Config.php
@@ -16,6 +16,11 @@
 class Mbiz_TrackingTags_Model_Config extends Mage_Core_Model_Abstract
 {
 
+    /**
+     * URL key attribute code for category
+     */
+    const CATEGORY_URL_KEY_ATTRIBUTE_CODE = 'url_key';
+
 // Monsieur Biz Tag NEW_CONST
 
 // Monsieur Biz Tag NEW_VAR


### PR DESCRIPTION
When using Magento EE, and especially when flat category is active, requesting the "url_key" attribute for a category fails because it is not populated in catalog_category_flat_store_*.
This PR fixes that.
